### PR TITLE
Note that the script only works on python2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 wtpa2-python
 ============
 
-python implementation of the WTPA2 sample packer/extractor
+python2 implementation of the WTPA2 sample packer/extractor
 
 Commands take the form of ``python wtpa2.py COMMAND ARGUMENTS``
 
@@ -19,3 +19,4 @@ Here are some example uses:
     python wtpa2.py extract samples.bin samples/
     python wtpa2.py extract --slots 8 /dev/sdc samples/
 
+where `python` points to a python2 interpreter.


### PR DESCRIPTION
Spend about 30 mins debugging this on my dads machine only to realize he was trying to run it through python3 and getting:

```
bret-mbr:wtpa2-python bret$ python3 wtpa2.py pack samples.bin /Volumes/WTPA2/aif
Traceback (most recent call last):
  File "wtpa2.py", line 210, in <module>
    wtpa.pack(args.outfile, args.infiles)
  File "wtpa2.py", line 25, in pack
    self.header[0:3] = "WTPA"
TypeError: can assign only bytes, buffers, or iterables of ints in range(0, 256)
```

Script worked great once it was used with python2.
